### PR TITLE
Don't downcase "salesInvoices" in URL path

### DIFF
--- a/lib/business_central/object/sales_invoice_line.rb
+++ b/lib/business_central/object/sales_invoice_line.rb
@@ -21,7 +21,7 @@ module BusinessCentral
 
         super(client, args)
         @parent_path << {
-          path: parent.downcase,
+          path: parent,
           id: parent_id
         }
       end


### PR DESCRIPTION
This was causing the url to be constructed as `salesinvoices` instead of `salesInvoices` which meant business central was returning a 404 when trying to perform requests on the `salesInvoiceLines` endpoint.

I think this might be an issue with endpoints like `salesOrderLine` as well: https://github.com/JDrizzy/business-central/blob/db599e59269927a744621b8b91ee46e0bb81b0a9/lib/business_central/object/sales_order_line.rb#L24

Happy to write some tests for this but will probably need a bit of direction as I'm not sure of the best way to test the URL has been structured correctly - specifically for nested endpoints.